### PR TITLE
sepolicy: Add missing mosey_server socket perms

### DIFF
--- a/mosey/vendor/mosey.te
+++ b/mosey/vendor/mosey.te
@@ -13,13 +13,15 @@ r_dir_file(mosey_server, sysfs_net)
 allow mosey_server mosey_server:netlink_netfilter_socket create;
 allow mosey_server self:capability { net_admin net_raw };
 allow mosey_server self:netlink_route_socket { create nlmsg_getneigh nlmsg_read nlmsg_readpriv nlmsg_write read write };
+allow mosey_server self:netlink_generic_socket create_socket_perms;
 allow mosey_server self:packet_socket create_stream_socket_perms;
 allow mosey_server self:tun_socket create;
 allow mosey_server self:udp_socket { create ioctl };
 allow mosey_server self:unix_dgram_socket ioctl;
 allow mosey_server tun_device:chr_file rw_file_perms;
 
+allowxperm mosey_server self:netlink_generic_socket ioctl SIOCETHTOOL;
 allowxperm mosey_server self:packet_socket ioctl { SIOCGIFFLAGS SIOCGIFHWADDR SIOCGIFINDEX };
-allowxperm mosey_server self:udp_socket ioctl { SIOCBONDINFOQUERY SIOCDEVPRIVATE_1 SIOCETHTOOL SIOCGIFFLAGS SIOCSIFFLAGS SIOCSIFHWADDR SIOCSIFMTU };
+allowxperm mosey_server self:udp_socket ioctl { SIOCBONDINFOQUERY SIOCDEVPRIVATE_1 SIOCETHTOOL SIOCGIFFLAGS SIOCSIFFLAGS SIOCSIFADDR SIOCSIFHWADDR SIOCSIFMTU SIOCDIFADDR };
 allowxperm mosey_server self:unix_dgram_socket ioctl { SIOCBONDINFOQUERY SIOCETHTOOL SIOCGIFFLAGS SIOCSIFFLAGS };
 allowxperm mosey_server tun_device:chr_file ioctl { TUNGETIFF TUNSETIFF };


### PR DESCRIPTION
Import the remaining socket permissions used by mosey_server from the stallion stock sepolicy dump.

Allow netlink_generic_socket creation and SIOCETHTOOL, and extend the udp_socket ioctl set with SIOCSIFADDR/SIOCDIFADDR so the imported Mosey policy matches stock behavior more closely.